### PR TITLE
Add crystal 0.35.1 support & elasticsearch 7.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,11 @@ All regular Crystal data types, which could be mapped from Elasticsearch data ty
 New object can be created from Hash (with string keys), NamedTuple or new Persistent object.
 
 ```crystal
-PostRepository.create({"user" => "kim", "message" => "some message", "tag" => "es", "time" => Time.now })
+PostRepository.create({"user" => "kim", "message" => "some message", "tag" => "es", "time" => Time.local })
 
-PostRepository.create(user: "eddy", message: "some message", tag: "es", time: Time.now )
+PostRepository.create(user: "eddy", message: "some message", tag: "es", time: Time.local )
 
-obj = Post.new({"user" => "kim", "message" => "some message", "tag" => "es", "time" => Time.now })
+obj = Post.new({"user" => "kim", "message" => "some message", "tag" => "es", "time" => Time.local })
 PostRepository.save(obj)
 ```
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: hermes.cr
+name: hermes
 version: 0.2.2
 
 authors:

--- a/spec/config.cr
+++ b/spec/config.cr
@@ -55,13 +55,13 @@ class TestIndex < Hermes::Index
         },
       },
 
-      user: {
-        properties: {
-          full_name: {type: "text"},
-          location:  {type: "geo_point"},
-          photo:     {type: "binary"},
-        },
-      },
+      # user: {
+      #   properties: {
+      #     full_name: {type: "text"},
+      #     location:  {type: "geo_point"},
+      #     photo:     {type: "binary"},
+      #   },
+      # },
     },
   })
 end
@@ -85,8 +85,8 @@ class PostRepository < Hermes::Repository(TestIndex, Post)
   document_type "posts"
 end
 
-class UserRepository < Hermes::Repository(TestIndex, User)
-end
+# class UserRepository < Hermes::Repository(TestIndex, User)
+# end
 
 class ShapeRepository < Hermes::Repository(AnotherIndex, Shape)
 end

--- a/spec/config.cr
+++ b/spec/config.cr
@@ -54,14 +54,19 @@ class TestIndex < Hermes::Index
           created_at: {:type => "date"},
         },
       },
+    },
+  })
+end
 
-      # user: {
-      #   properties: {
-      #     full_name: {type: "text"},
-      #     location:  {type: "geo_point"},
-      #     photo:     {type: "binary"},
-      #   },
-      # },
+class TestUserIndex < Hermes::Index
+  index_name "test_user_index"
+  config({
+    user: {
+    properties: {
+      full_name: {type: "text"},
+      location:  {type: "geo_point"},
+      photo:     {type: "binary"},
+      },
     },
   })
 end
@@ -85,8 +90,8 @@ class PostRepository < Hermes::Repository(TestIndex, Post)
   document_type "posts"
 end
 
-# class UserRepository < Hermes::Repository(TestIndex, User)
-# end
+class UserRepository < Hermes::Repository(TestUserIndex, User)
+end
 
 class ShapeRepository < Hermes::Repository(AnotherIndex, Shape)
 end

--- a/spec/factories.cr
+++ b/spec/factories.cr
@@ -1,5 +1,5 @@
 # TOOD: look to "like" field - default is brocken for hash
-def build_post(title = "some title", user = "eddy", text = "tratata", tag = "es", created_at = Time.new, likes = 0)
+def build_post(title = "some title", user = "eddy", text = "tratata", tag = "es", created_at = Time.local, likes = 0)
   Post.new(title: title, user: user, text: text, tag: tag, created_at: created_at, likes: likes)
 end
 

--- a/spec/hermes/repository_spec.cr
+++ b/spec/hermes/repository_spec.cr
@@ -8,9 +8,9 @@ describe Hermes::Repository do
   end
 
   describe "::document_type" do
-    # it "should return auto name if not specified" do
-    #   UserRepository.document_type.should eq("user")
-    # end
+    it "should return auto name if not specified" do
+      UserRepository.document_type.should eq("user")
+    end
 
     it "returns specified name" do
       PostRepository.document_type.should eq("posts")

--- a/spec/hermes/repository_spec.cr
+++ b/spec/hermes/repository_spec.cr
@@ -168,7 +168,7 @@ describe Hermes::Repository do
 
   describe "::create" do
     it "creates object by given hash" do
-      obj = PostRepository.create({:title => "t1", :user => "kim", :text => "test", :tag => "es", :created_at => Time.now})
+      obj = PostRepository.create({:title => "t1", :user => "kim", :text => "test", :tag => "es", :created_at => Time.local})
       obj.should be_a(Post)
       obj._id.should_not be_nil
       TestIndex.refresh
@@ -195,7 +195,7 @@ describe Hermes::Repository do
     end
 
     it "saves new object and assign new uid" do
-      p = Post.new({:title => "t1", :user => "kim", :text => "test", :tag => "es", :created_at => Time.now})
+      p = Post.new({:title => "t1", :user => "kim", :text => "test", :tag => "es", :created_at => Time.local})
       obj = PostRepository.save(p)
       p._id.should eq(obj._id)
       p._id.should_not be_nil

--- a/spec/hermes/repository_spec.cr
+++ b/spec/hermes/repository_spec.cr
@@ -8,9 +8,9 @@ describe Hermes::Repository do
   end
 
   describe "::document_type" do
-    it "should return auto name if not specified" do
-      UserRepository.document_type.should eq("user")
-    end
+    # it "should return auto name if not specified" do
+    #   UserRepository.document_type.should eq("user")
+    # end
 
     it "returns specified name" do
       PostRepository.document_type.should eq("posts")

--- a/spec/hermes/types/geo_point_spec.cr
+++ b/spec/hermes/types/geo_point_spec.cr
@@ -9,17 +9,17 @@ describe Hermes::Types::GeoPoint do
     end
   end
 
-  # context "as field of object" do
-  #   it "properly deserialized" do
-  #     obj = UserRepository.create(
-  #       full_name: "some name",
-  #       photo: Hermes::Types::Binary.new("asd"),
-  #       location: Hermes::Types::GeoPoint.new(1.0, 2.0),
-  #     )
-  #     TestIndex.refresh
-  #     obj = UserRepository.find!(obj._id)
-  #     obj.location.lat.should eq(1.0)
-  #     obj.location.lon.should eq(2.0)
-  #   end
-  # end
+  context "as field of object" do
+    it "properly deserialized" do
+      obj = UserRepository.create(
+        full_name: "some name",
+        photo: Hermes::Types::Binary.new("asd"),
+        location: Hermes::Types::GeoPoint.new(1.0, 2.0),
+      )
+      TestIndex.refresh
+      obj = UserRepository.find!(obj._id)
+      obj.location.lat.should eq(1.0)
+      obj.location.lon.should eq(2.0)
+    end
+  end
 end

--- a/spec/hermes/types/geo_point_spec.cr
+++ b/spec/hermes/types/geo_point_spec.cr
@@ -9,17 +9,17 @@ describe Hermes::Types::GeoPoint do
     end
   end
 
-  context "as field of object" do
-    it "properly deserialized" do
-      obj = UserRepository.create(
-        full_name: "some name",
-        photo: Hermes::Types::Binary.new("asd"),
-        location: Hermes::Types::GeoPoint.new(1.0, 2.0),
-      )
-      TestIndex.refresh
-      obj = UserRepository.find!(obj._id)
-      obj.location.lat.should eq(1.0)
-      obj.location.lon.should eq(2.0)
-    end
-  end
+  # context "as field of object" do
+  #   it "properly deserialized" do
+  #     obj = UserRepository.create(
+  #       full_name: "some name",
+  #       photo: Hermes::Types::Binary.new("asd"),
+  #       location: Hermes::Types::GeoPoint.new(1.0, 2.0),
+  #     )
+  #     TestIndex.refresh
+  #     obj = UserRepository.find!(obj._id)
+  #     obj.location.lat.should eq(1.0)
+  #     obj.location.lon.should eq(2.0)
+  #   end
+  # end
 end

--- a/spec/hermes_spec.cr
+++ b/spec/hermes_spec.cr
@@ -11,7 +11,7 @@ describe Hermes do
           tag:        "wow",
           user:       "kim",
           text:       "tralala",
-          created_at: Time.now,
+          created_at: Time.local,
         },
         {index: {_index: "test_index", _type: "posts"}},
         {
@@ -20,7 +20,7 @@ describe Hermes do
           tag:        "wow",
           user:       "eddy",
           text:       "tralala",
-          created_at: Time.now,
+          created_at: Time.local,
         },
       ])
       TestIndex.refresh

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,7 +10,7 @@ end
 Spec.before_each do
   query = {query: {match_all: {} of String => String}}
   PostRepository.delete_by_query(query)
-  # UserRepository.delete_by_query(query)
+  UserRepository.delete_by_query(query)
   ShapeRepository.delete_by_query(query)
   Hermes.refresh
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,7 +10,7 @@ end
 Spec.before_each do
   query = {query: {match_all: {} of String => String}}
   PostRepository.delete_by_query(query)
-  UserRepository.delete_by_query(query)
+  # UserRepository.delete_by_query(query)
   ShapeRepository.delete_by_query(query)
   Hermes.refresh
 end

--- a/src/hermes/client.cr
+++ b/src/hermes/client.cr
@@ -3,19 +3,23 @@ module Hermes
     property http
 
     def initialize
+      @headers = HTTP::Headers.new
+      @headers.add("Accept", "application/json")
+      @headers.add("Content-Type", "application/json")
+      
       @http = HTTP::Client.new(URI.new(Config.schema, Config.host, Config.port))
     end
 
     {% for method in [:get, :post, :put, :delete, :head] %}
       def {{method.id}}(url, headers = nil, body = nil)
-        res = @http.{{method.id}}(url, headers, body)
+        res = @http.{{method.id}}(url, @headers, body)
         Response.new(res)
       end
     {% end %}
-
+    
     {% for method in [:get, :post, :put, :delete] %}
       def {{method.id}}!(url, headers = nil, body = nil)
-        res = @http.{{method.id}}(url, headers, body)
+        res = @http.{{method.id}}(url, @headers, body)
         if res.status_code < 300
           Response.new(res)
         else

--- a/src/hermes/index.cr
+++ b/src/hermes/index.cr
@@ -1,6 +1,6 @@
 module Hermes
   class Index
-    alias OptionValue = String | Symbol | Int32 | Float32 | Float64 | Time | Hash(Symbol | String, OptionValue)
+    alias OptionValue = String | Symbol | Int32 | Int64 | Float32 | Float64 | Time | Hash(Symbol | String, OptionValue)
 
     @@config = {} of Symbol | String => OptionValue
 

--- a/src/hermes/persistent.cr
+++ b/src/hermes/persistent.cr
@@ -1,6 +1,6 @@
 module Hermes
   module Persistent
-    alias Any = String | Symbol | Time | Float32 | Float64 | Int32 | Int16 | ::Hermes::Types::Binary | ::Hermes::Types::IP | Hermes::Types::GeoPoint | Hermes::Types::IGeoShape | Hermes::Types::GeometryCollection | Hash(String | Symbol, Any)
+    alias Any = String | Symbol | Time | Float32 | Float64 | Int64 | Int32 | Int16 | ::Hermes::Types::Binary | ::Hermes::Types::IP | Hermes::Types::GeoPoint | Hermes::Types::IGeoShape | Hermes::Types::GeometryCollection | Hash(String | Symbol, Any)
 
     property _id = "", _index = "", _type = ""
 

--- a/src/hermes/repository.cr
+++ b/src/hermes/repository.cr
@@ -101,7 +101,6 @@ module Hermes
         Hermes.client.put(path(obj._id, refresh), nil, body)
       else
         res = Hermes.client.post(path(refresh), nil, body)
-        # NOT WORK
         # raise "Can't create. #{res.inspect}" unless res["created"]
         obj._id = res["_id"].as_s
       end

--- a/src/hermes/repository.cr
+++ b/src/hermes/repository.cr
@@ -101,7 +101,8 @@ module Hermes
         Hermes.client.put(path(obj._id, refresh), nil, body)
       else
         res = Hermes.client.post(path(refresh), nil, body)
-        raise "Can't create. #{res.inspect}" unless res["created"]
+        # NOT WORK
+        # raise "Can't create. #{res.inspect}" unless res["created"]
         obj._id = res["_id"].as_s
       end
       obj

--- a/src/hermes/search_response.cr
+++ b/src/hermes/search_response.cr
@@ -15,23 +15,6 @@ module Hermes
     @[JSON::Field(key: "_source")]
     @_source : T
 
-    # JSON.mapping(
-    #   _index: String,
-    #   _type: String,
-    #   _id: String,
-    #   _source: T
-    # )
-
-    # def self.new(pull : JSON::PullParser)
-      # instance = Hit(T).allocate
-      # p instance
-      # instance.initialize(pull)
-      # instance._source._id = instance._id
-      # instance._source._type = instance._type
-      # instance._source._index = instance._index
-      # instance
-    # end
-
     def _source
       @_source._id = @_id
       @_source._type = @_type
@@ -49,7 +32,7 @@ module Hermes
     include JSON::Serializable
 
     @[JSON::Field(key: "total")]
-    property total : Int32
+    property total : Int32 | Hash(String, JSON::Any)
 
 
     @[JSON::Field(key: "max_score")]
@@ -57,12 +40,6 @@ module Hermes
 
     @[JSON::Field(key: "hits")]
     property hits : Array(Hit(T))
-
-    # JSON.mapping(
-    #   total: Int32,
-    #   max_score: Float32?,
-    #   hits: Array(Hit(T))
-    # )
   end
 
   struct SearchResponse(T)
@@ -73,10 +50,6 @@ module Hermes
 
     @[JSON::Field(key: "aggregations")]
     property aggregations : Hash(String, JSON::Any)?
-
-    # JSON.mapping(
-    #   hits: Hits(T),
-    #   aggregations: {type: Hash(String, JSON::Any), nilable: true}
 
     def entries
       @hits.hits.map(&._source)
@@ -93,10 +66,6 @@ module Hermes
     @[JSON::Field(key: "aggregations")]
     property aggregations : Hash(String, JSON::Any)
     
-    # JSON.mapping(
-    #   aggregations: Hash(String, JSON::Any)
-    # )
-
     def aggs
       @aggregations
     end
@@ -107,10 +76,6 @@ module Hermes
 
     @[JSON::Field(key: "docs")]
     property docs : Array(Hit(T))
-
-    # JSON.mapping(
-    #   docs: Array(Hit(T))
-    # )
 
     def entries
       @docs.map(&._source)

--- a/src/hermes/search_response.cr
+++ b/src/hermes/search_response.cr
@@ -1,20 +1,43 @@
 module Hermes
   # TODO: probably should switch to struct but need to check case with high load
   struct Hit(T)
-    JSON.mapping(
-      _index: String,
-      _type: String,
-      _id: String,
-      _source: T
-    )
+    include JSON::Serializable
 
-    def self.new(pull : JSON::PullParser)
-      instance = Hit(T).allocate
-      instance.initialize(pull)
-      instance._source._id = instance._id
-      instance._source._type = instance._type
-      instance._source._index = instance._index
-      instance
+    @[JSON::Field(key: "_index")]
+    property _index : String
+
+    @[JSON::Field(key: "_type")]
+    property _type : String
+
+    @[JSON::Field(key: "_id")]
+    property _id : String
+
+    @[JSON::Field(key: "_source")]
+    @_source : T
+
+    # JSON.mapping(
+    #   _index: String,
+    #   _type: String,
+    #   _id: String,
+    #   _source: T
+    # )
+
+    # def self.new(pull : JSON::PullParser)
+      # instance = Hit(T).allocate
+      # p instance
+      # instance.initialize(pull)
+      # instance._source._id = instance._id
+      # instance._source._type = instance._type
+      # instance._source._index = instance._index
+      # instance
+    # end
+
+    def _source
+      @_source._id = @_id
+      @_source._type = @_type
+      @_source._index = @_index
+      
+      @_source
     end
 
     def entry
@@ -23,21 +46,40 @@ module Hermes
   end
 
   struct Hits(T)
-    JSON.mapping(
-      total: Int32,
-      max_score: Float32?,
-      hits: Array(Hit(T))
-    )
+    include JSON::Serializable
+
+    @[JSON::Field(key: "total")]
+    property total : Int32
+
+
+    @[JSON::Field(key: "max_score")]
+    property max_score : Float32?
+
+    @[JSON::Field(key: "hits")]
+    property hits : Array(Hit(T))
+
+    # JSON.mapping(
+    #   total: Int32,
+    #   max_score: Float32?,
+    #   hits: Array(Hit(T))
+    # )
   end
 
   struct SearchResponse(T)
-    JSON.mapping(
-      hits: Hits(T),
-      aggregations: {type: Hash(String, JSON::Any), nilable: true}
-    )
+    include JSON::Serializable
+
+    @[JSON::Field(key: "hits")]
+    property hits : Hits(T)
+
+    @[JSON::Field(key: "aggregations")]
+    property aggregations : Hash(String, JSON::Any)?
+
+    # JSON.mapping(
+    #   hits: Hits(T),
+    #   aggregations: {type: Hash(String, JSON::Any), nilable: true}
 
     def entries
-      hits.hits.map(&._source)
+      @hits.hits.map(&._source)
     end
 
     def aggs
@@ -46,9 +88,14 @@ module Hermes
   end
 
   struct AggregationResponse
-    JSON.mapping(
-      aggregations: Hash(String, JSON::Any)
-    )
+    include JSON::Serializable
+
+    @[JSON::Field(key: "aggregations")]
+    property aggregations : Hash(String, JSON::Any)
+    
+    # JSON.mapping(
+    #   aggregations: Hash(String, JSON::Any)
+    # )
 
     def aggs
       @aggregations
@@ -56,9 +103,14 @@ module Hermes
   end
 
   struct MultiGetResponse(T)
-    JSON.mapping(
-      docs: Array(Hit(T))
-    )
+    include JSON::Serializable
+
+    @[JSON::Field(key: "docs")]
+    property docs : Array(Hit(T))
+
+    # JSON.mapping(
+    #   docs: Array(Hit(T))
+    # )
 
     def entries
       @docs.map(&._source)

--- a/src/hermes/types/circle.cr
+++ b/src/hermes/types/circle.cr
@@ -1,11 +1,22 @@
 module Hermes
   module Types
     struct Circle < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(Float64),
-        radius: String
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(Float64)
+      
+      @[JSON::Field(key: "radius")]
+      property radius : String
+
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(Float64),
+      #   radius: String
+      # )
 
       def initialize(@coordinates, @radius)
         @type = "circle"

--- a/src/hermes/types/circle.cr
+++ b/src/hermes/types/circle.cr
@@ -12,12 +12,6 @@ module Hermes
       @[JSON::Field(key: "radius")]
       property radius : String
 
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(Float64),
-      #   radius: String
-      # )
-
       def initialize(@coordinates, @radius)
         @type = "circle"
       end

--- a/src/hermes/types/envelope.cr
+++ b/src/hermes/types/envelope.cr
@@ -9,11 +9,6 @@ module Hermes
       @[JSON::Field(key: "coordinates")]
       property coordinates : Array(Array(Float64))
 
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(Array(Float64))
-      # )
-
       def initialize(@coordinates)
         @type = "envelope"
       end

--- a/src/hermes/types/envelope.cr
+++ b/src/hermes/types/envelope.cr
@@ -1,10 +1,18 @@
 module Hermes
   module Types
     struct Envelope < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(Array(Float64))
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(Array(Float64))
+
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(Array(Float64))
+      # )
 
       def initialize(@coordinates)
         @type = "envelope"

--- a/src/hermes/types/geo_point.cr
+++ b/src/hermes/types/geo_point.cr
@@ -9,11 +9,6 @@ module Hermes
       @[JSON::Field(key: "lon")]
       property lon : Float64
 
-      # JSON.mapping(
-      #   lat: Float64,
-      #   lon: Float64
-      # )
-
       def initialize(@lat, @lon)
       end
     end

--- a/src/hermes/types/geo_point.cr
+++ b/src/hermes/types/geo_point.cr
@@ -1,10 +1,18 @@
 module Hermes
   module Types
     struct GeoPoint
-      JSON.mapping(
-        lat: Float64,
-        lon: Float64
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "lat")]
+      property lat : Float64
+
+      @[JSON::Field(key: "lon")]
+      property lon : Float64
+
+      # JSON.mapping(
+      #   lat: Float64,
+      #   lon: Float64
+      # )
 
       def initialize(@lat, @lon)
       end

--- a/src/hermes/types/geo_shape.cr
+++ b/src/hermes/types/geo_shape.cr
@@ -6,10 +6,18 @@ module Hermes
     end
 
     struct GeoShape < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(JSON::Any)
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(JSON::Any)
+
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(JSON::Any)
+      # )
 
       def initialize(@coordinates)
         @type = "geo_shape"

--- a/src/hermes/types/geo_shape.cr
+++ b/src/hermes/types/geo_shape.cr
@@ -14,11 +14,6 @@ module Hermes
       @[JSON::Field(key: "coordinates")]
       property coordinates : Array(JSON::Any)
 
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(JSON::Any)
-      # )
-
       def initialize(@coordinates)
         @type = "geo_shape"
       end

--- a/src/hermes/types/geometry_collection.cr
+++ b/src/hermes/types/geometry_collection.cr
@@ -3,10 +3,18 @@ require "./geo_shape"
 module Hermes
   module Types
     struct GeometryCollection
-      JSON.mapping(
-        type: String,
-        geometries: Array(GeoShape)
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "geometries")]
+      property geometries : Array(GeoShape)
+
+      # JSON.mapping(
+      #   type: String,
+      #   geometries: Array(GeoShape)
+      # )
 
       def initialize(@geometries)
         @type = "geometry_collection"

--- a/src/hermes/types/geometry_collection.cr
+++ b/src/hermes/types/geometry_collection.cr
@@ -11,11 +11,6 @@ module Hermes
       @[JSON::Field(key: "geometries")]
       property geometries : Array(GeoShape)
 
-      # JSON.mapping(
-      #   type: String,
-      #   geometries: Array(GeoShape)
-      # )
-
       def initialize(@geometries)
         @type = "geometry_collection"
       end

--- a/src/hermes/types/line_string.cr
+++ b/src/hermes/types/line_string.cr
@@ -1,10 +1,18 @@
 module Hermes
   module Types
     struct LineString < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(Array(Float64))
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(Array(Float64))
+
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(Array(Float64))
+      # )
 
       def initialize(@coordinates)
         @type = "line_string"

--- a/src/hermes/types/line_string.cr
+++ b/src/hermes/types/line_string.cr
@@ -9,11 +9,6 @@ module Hermes
       @[JSON::Field(key: "coordinates")]
       property coordinates : Array(Array(Float64))
 
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(Array(Float64))
-      # )
-
       def initialize(@coordinates)
         @type = "line_string"
       end

--- a/src/hermes/types/multi_line_string.cr
+++ b/src/hermes/types/multi_line_string.cr
@@ -1,10 +1,18 @@
 module Hermes
   module Types
     struct MultiLineString < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(Array(Array(Float64)))
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(Array(Array(Float64)))
+
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(Array(Array(Float64)))
+      # )
 
       def initialize(@coordinates)
         @type = "multi_line_string"

--- a/src/hermes/types/multi_line_string.cr
+++ b/src/hermes/types/multi_line_string.cr
@@ -9,11 +9,6 @@ module Hermes
       @[JSON::Field(key: "coordinates")]
       property coordinates : Array(Array(Array(Float64)))
 
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(Array(Array(Float64)))
-      # )
-
       def initialize(@coordinates)
         @type = "multi_line_string"
       end

--- a/src/hermes/types/multi_point.cr
+++ b/src/hermes/types/multi_point.cr
@@ -9,11 +9,6 @@ module Hermes
       @[JSON::Field(key: "coordinates")]
       property coordinates : Array(Array(Float64))
 
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(Array(Float64))
-      # )
-
       def initialize(@coordinates)
         @type = "multi_point"
       end

--- a/src/hermes/types/multi_point.cr
+++ b/src/hermes/types/multi_point.cr
@@ -1,10 +1,18 @@
 module Hermes
   module Types
     struct MultiPoint < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(Array(Float64))
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(Array(Float64))
+
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(Array(Float64))
+      # )
 
       def initialize(@coordinates)
         @type = "multi_point"

--- a/src/hermes/types/multi_polygon.cr
+++ b/src/hermes/types/multi_polygon.cr
@@ -1,10 +1,18 @@
 module Hermes
   module Types
     struct MultiPolygon < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(Array(Array(Array(Float64))))
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(Array(Array(Float64)))
+
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(Array(Array(Array(Float64))))
+      # )
 
       def initialize(@coordinates)
         @type = "multi_polygon"

--- a/src/hermes/types/multi_polygon.cr
+++ b/src/hermes/types/multi_polygon.cr
@@ -9,11 +9,6 @@ module Hermes
       @[JSON::Field(key: "coordinates")]
       property coordinates : Array(Array(Array(Float64)))
 
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(Array(Array(Array(Float64))))
-      # )
-
       def initialize(@coordinates)
         @type = "multi_polygon"
       end

--- a/src/hermes/types/point.cr
+++ b/src/hermes/types/point.cr
@@ -1,10 +1,18 @@
 module Hermes
   module Types
     struct Point < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(Float64)
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(Float64)
+      
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(Float64)
+      # )
 
       def initialize(@coordinates)
         @type = "point"

--- a/src/hermes/types/point.cr
+++ b/src/hermes/types/point.cr
@@ -9,11 +9,6 @@ module Hermes
       @[JSON::Field(key: "coordinates")]
       property coordinates : Array(Float64)
       
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(Float64)
-      # )
-
       def initialize(@coordinates)
         @type = "point"
       end

--- a/src/hermes/types/polygon.cr
+++ b/src/hermes/types/polygon.cr
@@ -11,11 +11,6 @@ module Hermes
       @[JSON::Field(key: "coordinates")]
       property coordinates : Array(Array(Array(Float64)))
 
-      # JSON.mapping(
-      #   type: String,
-      #   coordinates: Array(Array(Array(Float64)))
-      # )
-
       def initialize(@coordinates)
         @type = "polygon"
       end

--- a/src/hermes/types/polygon.cr
+++ b/src/hermes/types/polygon.cr
@@ -3,10 +3,18 @@ require "./multi_line_string"
 module Hermes
   module Types
     struct Polygon < IGeoShape
-      JSON.mapping(
-        type: String,
-        coordinates: Array(Array(Array(Float64)))
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "type")]
+      property type : String
+
+      @[JSON::Field(key: "coordinates")]
+      property coordinates : Array(Array(Array(Float64)))
+
+      # JSON.mapping(
+      #   type: String,
+      #   coordinates: Array(Array(Array(Float64)))
+      # )
 
       def initialize(@coordinates)
         @type = "polygon"

--- a/src/hermes/types/range.cr
+++ b/src/hermes/types/range.cr
@@ -8,11 +8,6 @@ module Hermes
       
       @[JSON::Field(key: "gte")]
       property gte : T
-      
-      # JSON.mapping(
-      #   lte: T,
-      #   gte: T
-      # )
 
       def initialize(@lte, @gte)
       end

--- a/src/hermes/types/range.cr
+++ b/src/hermes/types/range.cr
@@ -1,10 +1,18 @@
 module Hermes
   module Types
     struct Range(T)
-      JSON.mapping(
-        lte: T,
-        gte: T
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "lte")]
+      property lte : T
+      
+      @[JSON::Field(key: "gte")]
+      property gte : T
+      
+      # JSON.mapping(
+      #   lte: T,
+      #   gte: T
+      # )
 
       def initialize(@lte, @gte)
       end


### PR DESCRIPTION
Hi, these are the changes was made...

1) fixed shard error, as related in https://github.com/imdrasil/hermes.cr/issues/5

2) replaced time.now to time.local.

3) request without headers was failing, added by default content-type: application/json.

4) method save was crashing, seems that the actual response not coming more "created" as a key on headers.

5) replaced Json::Mapping to JSON::Serializable.

6) Any alias with support to int64.

The feature of creating different type to the same index, seems to be outdated and not is more able in versions more than 6.x, so i changed the UserRepository at test to one own index.
https://www.elastic.co/guide/en/elasticsearch/reference/6.7/removal-of-types.html